### PR TITLE
fix(answer_utils): match 'Final Answer:' in extract_pred_answer

### DIFF
--- a/inference_utils/answer_utils.py
+++ b/inference_utils/answer_utils.py
@@ -233,7 +233,7 @@ def extract_pred_answer(text: str) -> Optional[str]:
     if boxed is not None:
         return boxed
 
-    final_matches = re.findall(r"Final\\s+Answer\s*:\s*(.+)$", text, flags=re.IGNORECASE | re.MULTILINE)
+    final_matches = re.findall(r"Final\s+Answer\s*:\s*(.+)$", text, flags=re.IGNORECASE | re.MULTILINE)
     if final_matches:
         final_answer = final_matches[-1].strip()
         if final_answer:


### PR DESCRIPTION
Fixes #8

## Summary

The regex `r"Final\\s+Answer\s*:\s*(.+)$"` used `\\s` instead of `\s`, so in a raw string it expanded to a literal backslash + `s` rather than the whitespace class. Model output with `Final Answer: X` (and no `\boxed{}`) was never extracted; the function fell through to returning the full response.

## Change

Single-character fix on one line: `\\s` → `\s`.

## Verification

I do not have a GPU + 10 GB of HF checkpoints available locally for a full inference smoke test, so I verified by reproducing the regex behavior directly on five structurally distinct inputs:

| Input | Before | After |
|---|---|---|
| `Final Answer: 42` | `'Final Answer: 42'` (full text fallback) | `'42'` |
| `We compute step 1.\nFinal Answer: 7` | full text | `'7'` |
| `FINAL  ANSWER : -3.14` | full text | `'-3.14'` |
| `the answer is \boxed{99}` | `'99'` (boxed wins) | `'99'` unchanged |
| `no marker just text` | `'no marker just text'` | `'no marker just text'` unchanged |

The choice-dataset path (`extract_choice_answer` line 174) already uses the correct `r"Final\s*(?:Choice|Answer)..."` and is unaffected.

## Impact

This likely shifts reported math500 accuracy upward for `--style sequential_light` and `--style sequential_scaled`. I'd appreciate if a maintainer with the inference setup ready could measure the delta and append it here — happy to update the PR description with the numbers.