### PR TITLE
refactor(lcb_utils): remove unreachable code in evaluate_generated_code

### DIFF
--- a/inference_utils/lcb_utils.py
+++ b/inference_utils/lcb_utils.py
@@ -975,32 +975,3 @@ def evaluate_generated_code(code: str, eval_sample: Mapping[str, Any], timeout_s
         outputs=list(eval_sample.get("outputs", []) or []),
         timeout_s=timeout_s,
     )
-
-
-    if str(eval_sample.get("mode", "stdin")) == "functional":
-        fn_name = str(eval_sample.get("fn_name", "") or "")
-        inputs = list(eval_sample.get("inputs", []) or [])
-        outputs = list(eval_sample.get("outputs", []) or [])
-        isolated = str(os.environ.get("LCB_FUNCTIONAL_ISOLATED", "1")).strip().lower() not in {"0", "false", "no"}
-        if isolated:
-            return run_functional_tests_subprocess(
-                code=code,
-                fn_name=fn_name,
-                inputs=inputs,
-                outputs=outputs,
-                timeout_s=timeout_s,
-            )
-        return run_functional_tests(
-            code=code,
-            fn_name=fn_name,
-            inputs=inputs,
-            outputs=outputs,
-            timeout_s=timeout_s,
-        )
-
-    return run_stdio_tests(
-        code=code,
-        inputs=list(eval_sample.get("inputs", []) or []),
-        outputs=list(eval_sample.get("outputs", []) or []),
-        timeout_s=timeout_s,
-    )


### PR DESCRIPTION
Fixes #10

## Summary

Removes 29 lines (978-1006) of unreachable code at the end of `evaluate_generated_code`. The block is a duplicate of the live dispatcher (lines 952-977) and is dominated by the unconditional `return run_stdio_tests(...)` at line 972. Vulture flags it at 100% confidence.

## Verification

- `python -m py_compile inference_utils/lcb_utils.py` passes.
- Re-running `vulture --min-confidence 80 inference_utils/lcb_utils.py` no longer reports line 980.

Pure cleanup — no functional change.