### PR TITLE
refactor(answer_utils): remove dead code after return in compare_answers

### DIFF
--- a/inference_utils/answer_utils.py
+++ b/inference_utils/answer_utils.py
@@ -480,16 +480,6 @@ def compare_answers(
 
     return gold_answer, pred_answer, False, fallback_gold, fallback_pred
 
-    pred_answer = extract_boxed_answer(pred_text)
-    gold_norm = normalize_answer_string(gold_answer)
-    if pred_answer is None:
-        return gold_answer, None, False, gold_norm, ""
-    pred_norm = normalize_answer_string(pred_answer)
-    if not gold_norm or not pred_norm:
-        return gold_answer, pred_answer, False, gold_norm, pred_norm
-    correct = gold_norm == pred_norm
-    return gold_answer, pred_answer, correct, gold_norm, pred_norm
-
 
 def format_latent_info(latent: torch.Tensor) -> str:
     steps = int(latent.size(0)) if latent.ndim >= 1 else 0


### PR DESCRIPTION
Fixes #12

## Summary

Removes 9 unreachable lines at the end of `compare_answers`. The block follows an unconditional return and is flagged by vulture at 100% confidence.

## Verification

- `python -m py_compile inference_utils/answer_utils.py` passes.
- Re-running `vulture --min-confidence 80 inference_utils/answer_utils.py` no longer reports line 483.

Pure cleanup — no functional change.