### PR TITLE
fix: correct stale data/medqa.json references after rename to dataset/

### DIFF
--- a/hf_resolver.py
+++ b/hf_resolver.py
@@ -74,7 +74,7 @@ def resolve_medqa_dataset_arg(dataset: str, release_code_root: Path) -> str:
     if default_path.is_file():
         return str(default_path)
     raise FileNotFoundError(
-        "MedQA json not found at release_code/dataset/medqa.json"
+        f"MedQA json not found at {default_path}"
     )
 
 

--- a/inference_utils/answer_utils.py
+++ b/inference_utils/answer_utils.py
@@ -11,8 +11,8 @@ _MATH500_KEYS = {"math500", "math-500", "huggingfaceh4/math-500"}
 _MEDQA_KEYS = {
     "medqa",
     "local/medqa",
-    "data/medqa.json",
-    "./data/medqa.json",
+    "dataset/medqa.json",
+    "./dataset/medqa.json",
 }
 _GPQA_KEYS = {
     "gpqa",

--- a/inference_utils/inference_mas.py
+++ b/inference_utils/inference_mas.py
@@ -246,10 +246,10 @@ def load_eval_questions_and_answers(
     if dataset_name == "__local_medqa__":
         medqa_path = dataset
         if not os.path.isfile(medqa_path):
-            medqa_path = "data/medqa.json"
+            medqa_path = "dataset/medqa.json"
         if not os.path.isfile(medqa_path):
             raise FileNotFoundError(
-                f"medqa file not found. expected '{dataset}' or 'data/medqa.json'."
+                f"medqa file not found. expected '{dataset}' or 'dataset/medqa.json'."
             )
 
         records = _load_medqa_records(medqa_path)


### PR DESCRIPTION
Fixes #14

## Summary

Three files referenced the old `data/medqa.json` path; the actual on-disk location is `dataset/medqa.json`. Updates `_MEDQA_KEYS` in `answer_utils.py`, the fallback path + error message in `inference_mas.py`, and the misleading error message in `hf_resolver.py` (which now uses the actual resolved path instead of a hardcoded prefix).

## Verification

```python
>>> from inference_utils.answer_utils import is_medqa_dataset
>>> is_medqa_dataset("dataset/medqa.json")
True   # was False
>>> is_medqa_dataset("data/medqa.json")
False  # was True
>>> is_medqa_dataset("medqa")
True   # unchanged
```

`python -m py_compile` passes on all three files.

A grep of the repo finds no callers passing the literal string `"data/medqa.json"`, so removing it from `_MEDQA_KEYS` is safe.