### PR TITLE
feat(run): include latent_length sweep summary in final result line

### DIFF
--- a/run.py
+++ b/run.py
@@ -357,7 +357,7 @@ def main() -> int:
 
     best_ls, best_metric_name, best_metric_value = max(results, key=lambda x: x[2])
     joined = ", ".join(f"ls={ls}:{name}={value:.2f}%" for ls, name, value in results)
-    print(f"[result] {best_metric_name}={best_metric_value:.2f}%")
+    print(f"[result] {best_metric_name}={best_metric_value:.2f}% (best at latent_length={best_ls}; sweep: {joined})")
     return 0
 
 


### PR DESCRIPTION
Fixes #16

## Summary

Restores the latent-length sweep summary to the `[result]` print at the end of `run.py`. Both `best_ls` and `joined` were already computed but never emitted; ruff flagged them as unused (`F841` / `RUF059`).

## Behavior change

The existing `[result]` log line gains a suffix:

```
[result] accuracy=72.40% (best at latent_length=48; sweep: ls=16:accuracy=68.20%, ls=32:accuracy=70.80%, ls=48:accuracy=72.40%)
```

When the sweep is collapsed to a single value (the typical case after `apply_recommended_settings` fills in the recommended latent_length), the suffix becomes `(best at latent_length=N; sweep: ls=N:accuracy=X%)` — slightly redundant but harmless.

## Verification

- `python -m py_compile run.py` passes.
- `python run.py --help` prints usage cleanly.
- `ruff check run.py --select=F841,RUF059` → no errors after the change.

Open to a different format (e.g., `[sweep]` as its own line) — happy to iterate.