### PR TITLE
Fix Star History chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -356,11 +356,11 @@ We welcome discussions and contributions to RecursiveMAS! If you would like to s
 ## 🌟 Star History
 Please kindly give us a GitHub Star ⭐️ if you find our project is helpful!
 
-<a href="https://www.star-history.com/?repos=RecursiveMAS%2FRecursiveMAS&type=date&legend=top-left">
+<a href="https://star-history.dera.page/#RecursiveMAS/RecursiveMAS&type=date">
  <picture>
-   <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/chart?repos=RecursiveMAS/RecursiveMAS&type=date&theme=dark&legend=top-left" />
-   <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/chart?repos=RecursiveMAS/RecursiveMAS&type=date&legend=top-left" />
-   <img alt="Star History Chart" src="https://api.star-history.com/chart?repos=RecursiveMAS/RecursiveMAS&type=date&legend=top-left" />
+   <source media="(prefers-color-scheme: dark)" srcset="https://star-history.dera.page/svg?repos=RecursiveMAS/RecursiveMAS&type=date&theme=dark&legend=top-left" />
+   <source media="(prefers-color-scheme: light)" srcset="https://star-history.dera.page/svg?repos=RecursiveMAS/RecursiveMAS&type=date&legend=top-left" />
+   <img alt="Star History Chart" src="https://star-history.dera.page/svg?repos=RecursiveMAS/RecursiveMAS&type=date&legend=top-left" />
  </picture>
 </a>
 


### PR DESCRIPTION
The Star History chart in the README is currently broken due to GitHub stargazer API restrictions. This MR switches it to a working mirror so the chart renders again.